### PR TITLE
Add components with documentation blocks to storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,6 +2,16 @@ import type { StorybookConfig } from '@storybook/react-vite'
 
 const config: StorybookConfig = {
 	stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+	typescript: {
+		reactDocgen: 'react-docgen-typescript',
+		reactDocgenTypescriptOptions: {
+			compilerOptions: {
+				allowSyntheticDefaultImports: false,
+				esModuleInterop: false,
+			},
+			propFilter: () => true,
+		},
+	},
 	addons: [
 		'@storybook/addon-links',
 		'@storybook/addon-essentials',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cretia/components",
 	"description": "Cretia components library",
-	"version": "0.0.2-alpha.10",
+	"version": "0.0.2-alpha.11",
 	"files": [
 		"dist",
 		"styles",

--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -1,14 +1,17 @@
+// import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { Button } from '.'
+import { ButtonBase } from './ButtonBase'
 
-const meta: Meta<typeof Button> = {
-	component: Button,
+const meta = {
+	title: 'Components/Button',
+	component: ButtonBase,
 	tags: ['autodocs'],
-}
+} satisfies Meta<typeof ButtonBase>
 
 export default meta
-type Story = StoryObj<typeof Button>
+
+type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
 	args: {
@@ -19,6 +22,6 @@ export const Default: Story = {
 export const Destructive: Story = {
 	args: {
 		destructive: true,
-		children: 'Danger!',
+		children: 'Cancel',
 	},
 }

--- a/src/Button/ButtonBase.tsx
+++ b/src/Button/ButtonBase.tsx
@@ -1,0 +1,84 @@
+import { ReactElement } from 'react'
+
+import * as Styles from './styled'
+
+interface Props {
+	/**what will be rendered inside the button. It represents the content or label of the button */
+	children?: any
+	/** Click callback, with event object passed as argument */
+	onClick?: () => void
+	/** When set to `true`, this prop makes the button smaller in size. */
+	small?: boolean
+	/** gives the button a solid background when set to `true` */
+	solid?: boolean
+	/** gitves the submit attribute to the button element */
+	submit?: boolean
+	/**to display the button inline with other elements */
+	inline?: boolean
+	/** center alignment of the button */
+	center?: boolean
+	/** set the button as the default action */
+	default?: boolean
+	/** disables the button when set to `true` */
+	disabled?: boolean
+	/** control whether the button is in read-only mode */
+	readOnly?: boolean
+	/** indicates that the button is required for a certain action */
+	required?: boolean
+	/** when set to `true` styles of the button change to red to indicate a irreversible action */
+	destructive?: boolean
+	/** when set to `true` the button background disspaears */
+	$transparent?: boolean
+	as?: string | ReactElement
+	name?: string
+	/** */
+	title?: string
+}
+
+export { baseButtonStyles } from './styled'
+
+/**Cretia actions buttons
+ *
+ * Renders a default `button` that can be styled with the `destructive`,
+ *
+ * `solid` and `$transparent` props.
+ */
+
+function ButtonBase(props: Props) {
+	const {
+		name = 'react',
+		title,
+		submit = false,
+		inline = false,
+		center = false,
+		readOnly = false,
+		required = false,
+		children,
+		disabled = false,
+		destructive = false,
+		solid = submit,
+		small = inline,
+		$transparent = inline,
+	} = props
+	const useButton = !submit && typeof children !== 'string'
+
+	return (
+		<Styles.Container
+			name={name}
+			small={small}
+			solid={solid}
+			$center={center}
+			disabled={disabled}
+			readOnly={readOnly}
+			required={required}
+			$destructive={destructive}
+			$transparent={$transparent}
+			type={submit ? 'submit' : 'button'}
+			{...(useButton
+				? { as: 'button' as any, children: children || title }
+				: { value: children || title })}
+		/>
+	)
+}
+
+export { ButtonBase }

--- a/src/Checkbox/Checkbox.stories.ts
+++ b/src/Checkbox/Checkbox.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { CheckboxBase } from '.'
+
+const meta = {
+	title: 'Components/Checkbox',
+	component: CheckboxBase,
+	tags: ['autodocs'],
+} satisfies Meta<typeof CheckboxBase>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	args: {
+		name: '',
+		checked: true,
+	},
+}

--- a/src/Checkbox/index.tsx
+++ b/src/Checkbox/index.tsx
@@ -4,21 +4,34 @@ import { styled } from 'styled-components'
 import { Label } from './styled'
 
 type Props = {
+	/** overrides `CSSProperties` */
 	style?: CSSProperties
+	/** `name` attribute of `input` */
 	name: string
+	/** Sets the checkbox checked value */
 	checked?: boolean
+	/** indicates that is required for a certain action */
 	required?: boolean
+	/** Change callback invoked when the value of the `input` changes */
 	onChange?: (event: ChangeEvent<HTMLInputElement>) => any
+	/** Content of `label` element */
 	label?: ReactNode
+	/** `id` attribute of `input` */
 	id?: string
+	/** Sets the `value` attribute of the `input` */
 	value?: string
+	/** disables the checkbox when set to `true` */
 	disabled?: boolean
+	/** control whether the checkbox is in read-only mode */
 	readOnly?: boolean
 }
 
 const styles = { input: { marginRight: 4, flexShrink: 0 } }
 
-function CheckboxBase(props: Props): ReactElement {
+/**
+ * Cretia styled checkbox with built-in label.
+ */
+export function CheckboxBase(props: Props): ReactElement {
 	const {
 		style = {},
 		label,
@@ -31,7 +44,6 @@ function CheckboxBase(props: Props): ReactElement {
 		disabled,
 		readOnly,
 	} = props
-
 	return (
 		<Label key={String(checked)} style={style} htmlFor={id}>
 			<input

--- a/src/ColorPicker/ColorPicker.stories.tsx
+++ b/src/ColorPicker/ColorPicker.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { ColorPickerBase } from '.'
+
+const meta = {
+	title: 'Components/ColorPicker',
+	component: ColorPickerBase,
+	tags: ['autodocs'],
+} satisfies Meta<typeof ColorPickerBase>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	args: { name: 'helloworld', value: '#fff' },
+}

--- a/src/ColorPicker/index.tsx
+++ b/src/ColorPicker/index.tsx
@@ -8,13 +8,23 @@ import * as Styled from './styled'
 
 interface Props {
 	value: string
+	/** `name` attribute of `input` */
 	name: string
+	/** control whether the color picker is in read-only mode */
 	readOnly?: boolean
+	/** displayed if theres an error message as `string` */
 	error?: string | false
+	/** Change callback invoked when the value of the `input` changes */
 	onChange?: (value: any) => void
 }
 
-function ColorPickerBase({
+/**
+ * Select a color from the range displayed to replace the component value with
+ *
+ * it's correspondant HEX
+ */
+
+export function ColorPickerBase({
 	value = '#ffffff',
 	onChange = () => undefined,
 	name,

--- a/src/File/File.stories.ts
+++ b/src/File/File.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { FileBase } from '.'
+
+const meta = {
+	title: 'Components/File',
+	component: FileBase,
+	tags: ['autodocs'],
+} satisfies Meta<typeof FileBase>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	args: { name: 'helloworld.pdf', value: 'helloworld.pdf', label: '' },
+}

--- a/src/File/index.tsx
+++ b/src/File/index.tsx
@@ -4,19 +4,28 @@ import { styled } from 'styled-components'
 import * as Styled from './styled'
 
 interface Props {
+	/** Content of `label` element */
 	label: string
+	/** Sets the `value` attribute of the `input` */
 	value: any
+	/** `name` attribute of `input` */
 	name: string
+	/** `id` attribute of the file */
 	id?: string
+	/** disables the access to file when set to `true` */
 	disabled?: boolean
+	/** sets dark styles when set to `true`*/
 	dark?: boolean
 	accept?: string
+	/** acceps a url for the file preview */
 	previewUrl?: string
+	/** Change callback invoked when the value of the `input` changes */
 	onChange?: ((event: ChangeEvent<HTMLInputElement>) => void) | undefined
+	/** removes the `padding` when set to `true` */
 	paddingless?: boolean
 }
 
-function FileBase(props: Props): ReactElement {
+export function FileBase(props: Props): ReactElement {
 	const {
 		label,
 		value,

--- a/src/Pill/Pill.stories.ts
+++ b/src/Pill/Pill.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { PillBase } from '.'
+
+const meta = {
+	title: 'Components/Pill',
+	component: PillBase,
+	tags: ['autodocs'],
+} satisfies Meta<typeof PillBase>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	args: { message: 'This is a message' },
+}

--- a/src/Pill/index.tsx
+++ b/src/Pill/index.tsx
@@ -8,11 +8,23 @@ import { styled } from 'styled-components'
 import * as Styles from './styles'
 
 interface Props {
+	/** content that will be displayed on the pill */
 	message?: string | ReactElement | ReactNode
+	/** content that will be displayed on the pill */
 	children?: string | ReactElement | ReactNode
+	/** overrides `CSSProperties` */
 	style?: CSSProperties
+	/** */
 	icon?: ReactNode
 }
+
+/** Display an important message with Cretia styled Pill
+ *
+ * add a related icon trough the `icon` prop or pass a `button`
+ *
+ * to the children `prop` to emphazise it
+ *
+ */
 
 export function PillBase(
 	props: Props & React.ComponentProps<typeof Styles.Container>,

--- a/src/Popup/Popup.stories.ts
+++ b/src/Popup/Popup.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { PopupBase } from '.'
+
+const meta = {
+	title: 'Components/Popup',
+	component: PopupBase,
+	tags: ['autodocs'],
+} satisfies Meta<typeof PopupBase>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	args: { children: 'ReactNode', relative: false, visible: true },
+}

--- a/src/Popup/index.tsx
+++ b/src/Popup/index.tsx
@@ -3,16 +3,17 @@ import { styled } from 'styled-components'
 
 import * as Styled from './styled'
 
-type Props = {
+interface Props {
 	children: ReactNode
 	onDismiss: () => void
 	relative: boolean
 	visible: boolean
 }
 
-const PopupBase = forwardRef(function TooltipComponent(props: Props, ref: any) {
-	const { children, onDismiss, visible, ...moreProps } = props
-
+export const PopupBase = forwardRef(function TooltipComponent(
+	{ children, onDismiss, visible = true, ...moreProps }: Props,
+	ref: any,
+) {
 	const tooltipRef = useRef<HTMLDivElement>(null)
 
 	useEffect(() => {

--- a/src/Radio/Radio.stories.ts
+++ b/src/Radio/Radio.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { RadioBase } from '.'
+
+const meta = {
+	title: 'Components/Radio',
+	component: RadioBase,
+	tags: ['autodocs'],
+} satisfies Meta<typeof RadioBase>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	args: { value: 'any', checked: false, name: 'string', label: 'string' },
+}

--- a/src/Radio/index.tsx
+++ b/src/Radio/index.tsx
@@ -3,16 +3,28 @@ import { styled } from 'styled-components'
 
 import * as Styles from './styles'
 
-type Props = {
+interface Props {
+	/**
+	 * selected option by input value (fully controlled)
+	 * When passing a `value` prop, you must use the `onChange`
+	 * hanlder to update the `value`
+	 */
 	value: any
+	/** Sets the radio checked value */
 	checked: boolean
+	/** `name` attribute of `input` */
 	name: string
+	/** Content of `label` element */
 	label: string
+	/** change callback invoked with input value */
 	onChange: (event: ChangeEvent<HTMLInputElement>) => void
+	/** Optional value for `id` attribute */
 	id?: string
 }
 
-function RadioBase(props: Props): ReactElement {
+/**Radio button styled by Cretia */
+
+export function RadioBase(props: Props): ReactElement {
 	const {
 		value,
 		checked,
@@ -22,7 +34,6 @@ function RadioBase(props: Props): ReactElement {
 		id = `${name}-${value}`,
 		...moreProps
 	} = props
-
 	return (
 		<Styles.Label data-testid="radio-label" htmlFor={id} {...moreProps}>
 			{label}

--- a/src/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { SegmentedControlBase } from '.'
+
+const meta = {
+	title: 'Components/SegmentedControl',
+	component: SegmentedControlBase,
+	tags: ['autodocs'],
+} satisfies Meta<typeof SegmentedControlBase>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	args: {
+		id: '',
+		name: 'Segmented Control',
+		segments: [
+			{ value: 'First', label: 'First' },
+			{ value: 'Second', label: 'Second' },
+		],
+		label: 'Segmented Control',
+		disabled: false,
+		readOnly: false,
+	},
+}

--- a/src/SegmentedControl/index.tsx
+++ b/src/SegmentedControl/index.tsx
@@ -9,18 +9,33 @@ type Segment = {
 	id?: string
 }
 
-type Props = {
+interface Props {
+	/** Sets the `value` attribute of the `input` */
 	value: any
+	/** `id` attribute of `input` */
 	id?: string
 	name?: string
+	/** Content of `label` element */
 	label?: string
+	/**Array of segment objects composed of:
+	 *
+	 *  `{ value: '', label: '', id: ''}`
+	 *
+	 * */
 	segments: Segment[]
+	/** Change callback invoked when the value of the `input` changes */
 	onChange: (_: { target: { name?: string; value?: any } }) => unknown
+	/** disables the segmented control when set to `true` */
 	disabled?: boolean
+	/** control whether the segmented control is in read-only mode */
 	readOnly?: boolean
-} & Omit<ComponentProps<typeof Styles.Container>, 'onChange'>
+}
 
-function SegmentedControlBase(props: Props): ReactElement {
+/** Make a selection from a set of mutually exclusive options. */
+
+export function SegmentedControlBase(
+	props: Props & Omit<ComponentProps<typeof Styles.Container>, 'onChange'>,
+): ReactElement {
 	const {
 		name,
 		segments,

--- a/src/Tag/Tag.stories.tsx
+++ b/src/Tag/Tag.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Tag } from '.'
 
 const meta: Meta<typeof Tag> = {
+	title: 'Components/Tag',
 	component: Tag,
 	tags: ['autodocs'],
 }

--- a/src/Tag/index.tsx
+++ b/src/Tag/index.tsx
@@ -12,6 +12,10 @@ const tagTypeColors = {
 	high: 'var(--human-color--red)',
 }
 
+/**
+ * A rounded rectangle inline label.
+ */
+
 export const Tag = styled.span<{
 	$type?:
 		| 'error'

--- a/src/Tooltip/Tooltip.stories.tsx
+++ b/src/Tooltip/Tooltip.stories.tsx
@@ -1,17 +1,18 @@
 import React from 'react'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 
-import { Tooltip } from '.'
+import { TooltipBase } from '.'
 
 export default {
 	title: 'Components/Tooltip',
-	component: Tooltip,
-} as ComponentMeta<typeof Tooltip>
+	component: TooltipBase,
+	tags: ['autodocs'],
+} as ComponentMeta<typeof TooltipBase>
 
-const Template: ComponentStory<typeof Tooltip> = (args) => (
-	<Tooltip {...args}>
+const Template: ComponentStory<typeof TooltipBase> = (args) => (
+	<TooltipBase {...args}>
 		<p>Hover me</p>
-	</Tooltip>
+	</TooltipBase>
 )
 
 export const Default = Template.bind({})

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -15,15 +15,22 @@ const TooltipProvider = TooltipPrimitive.Provider
 const TooltipTrigger = TooltipPrimitive.Trigger
 const TooltipContent = StyledContent
 
-function TooltipBase({
-	content,
-	children,
-	side = 'top',
-}: {
+interface Props {
+	/** Content inside rhe tooltip*/
 	content: React.ReactNode | string
+	/** The root node of JSX passed into Tooltip as children will act as the tooltip trigger */
 	children: React.ReactNode
+	/** Sets prefferred side of the trigger the tooltip should appear */
 	side?: 'top' | 'right' | 'bottom' | 'left'
-}) {
+}
+
+/**
+ * Renders a tooltip on hover or focus of a trigger.
+ *
+ * The tooltip will position itself based on the `side` prop.
+ */
+
+export function TooltipBase({ content = '', children, side = 'top' }: Props) {
 	return (
 		<TooltipProvider>
 			<TooltipPrimitive.Root delayDuration={0}>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -71,6 +71,15 @@
 	--border_radius--x_large: 20px;
 
 	/* Sizes for tablet and larger */
+
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+		Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+	quotes: '“' '”';
+	font-size: 1rem;
+	letter-spacing: -0.022em;
+	font-style: normal;
+	color: var(--human-color--text);
+	direction: ltr;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## PR Description

Components were added to storybook:

- Checkbox
- ColorPicker
- File
- Pill
- Popup
- Radio
- SegmentedControl
- Tooltip

Remains: TextInput

All of them with props documentation and a brief introduction

### Screen Shots/Recordings

![Captura de pantalla (916)](https://github.com/cretia-app/components/assets/72099737/f55ba5f6-8cd0-46e7-8955-ecab2751a3e0)

![Captura de pantalla (917)](https://github.com/cretia-app/components/assets/72099737/b5175666-38e0-4189-a294-3c930cab77a9)

### Related Issues/Tickets

Closes #5
